### PR TITLE
[WIP] remove "mkdir" from the dependencies of "clean"

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -85,7 +85,7 @@
 	</target>
 	<target name="dist" depends="help,jar,archive" description="generate the distribution"/>
 
-	<target name="clean" depends="mkdir" description="clean up">
+	<target name="clean" description="clean up">
 		<!-- Delete the ${build} and ${dist} directory trees -->
 		<delete>
 			<fileset dir="${build}" includes="**"/>

--- a/build.xml
+++ b/build.xml
@@ -87,8 +87,8 @@
 
 	<target name="clean" description="clean up">
 		<!-- Delete the ${build} and ${dist} directory trees -->
-		<delete>
-			<fileset dir="${build}" includes="**"/>
+		<delete includeemptydirs="true">
+			<fileset dir="${build}/"/>
 			<fileset file="${bin}/lmntal.jar"/>
 			<fileset file="lmntal.tgz"/>
 			<fileset file="${src}/runtime/Help.java"/>


### PR DESCRIPTION
`git clean` しないと `classes` が消えてくれない問題の解決