### PR TITLE
Feature/add float2int

### DIFF
--- a/src/compile/GuardCompiler.java
+++ b/src/compile/GuardCompiler.java
@@ -115,8 +115,8 @@ class GuardCompiler extends LHSCompiler
 //		putLibrary("lognot"    , 2, 1, array(ISINT  , Instruction.INOT,   ISINT));
 		putLibrary("+."   , 2, 1, array(ISFLOAT,      -1,            ISFLOAT));
 		putLibrary("-."   , 2, 1, array(ISFLOAT, Instruction.FNEG,   ISFLOAT));
-		putLibrary("int"  , 2, 1, array(ISINT,   Instruction.FLOAT2INT, ISFLOAT)); 
-		putLibrary("float", 2, 1, array(ISFLOAT, Instruction.INT2FLOAT, ISINT)); 
+		putLibrary("int"  , 2, 1, array(ISFLOAT, Instruction.FLOAT2INT, ISINT)); 
+		putLibrary("float", 2, 1, array(ISINT  , Instruction.INT2FLOAT, ISFLOAT)); 
 		if (Env.hyperLink)
 		{
 			putLibrary("new"       , 1, 0, array(Instruction.NEWHLINK, ISINT));

--- a/src/compile/GuardCompiler.java
+++ b/src/compile/GuardCompiler.java
@@ -115,6 +115,8 @@ class GuardCompiler extends LHSCompiler
 //		putLibrary("lognot"    , 2, 1, array(ISINT  , Instruction.INOT,   ISINT));
 		putLibrary("+."   , 2, 1, array(ISFLOAT,      -1,            ISFLOAT));
 		putLibrary("-."   , 2, 1, array(ISFLOAT, Instruction.FNEG,   ISFLOAT));
+		putLibrary("int"  , 2, 1, array(ISINT,   Instruction.FLOAT2INT, ISFLOAT)); 
+		putLibrary("float", 2, 1, array(ISFLOAT, Instruction.INT2FLOAT, ISINT)); 
 		if (Env.hyperLink)
 		{
 			putLibrary("new"       , 1, 0, array(Instruction.NEWHLINK, ISINT));

--- a/src/runtime/Instruction.java
+++ b/src/runtime/Instruction.java
@@ -1478,6 +1478,7 @@ public class Instruction implements Cloneable
 	static {setArgType(FEQ, new ArgType(false, ARG_ATOM, ARG_ATOM));}
 	static {setArgType(FNE, new ArgType(false, ARG_ATOM, ARG_ATOM));}
 
+	// int と float の相互変換の組み込みガード命令 (630--639+OPT)
 	@LMNtalIL public static final int FLOAT2INT = 630; 
 	@LMNtalIL public static final int INT2FLOAT = 631; 
 	static {setArgType(FLOAT2INT, new ArgType(true, ARG_ATOM, ARG_ATOM));} 
@@ -1486,7 +1487,7 @@ public class Instruction implements Cloneable
 	@LMNtalIL public static final int INT2FLOATFUNC = INT2FLOAT + OPT; 
 	static {setArgType(FLOAT2INTFUNC, new ArgType(true, ARG_VAR, ARG_VAR));} 
 	static {setArgType(INT2FLOATFUNC, new ArgType(true, ARG_VAR, ARG_VAR));} 
-	
+
 	//グループ化に関する命令
 	/**
 	 * group [subinsts]

--- a/src/runtime/Instruction.java
+++ b/src/runtime/Instruction.java
@@ -1478,6 +1478,15 @@ public class Instruction implements Cloneable
 	static {setArgType(FEQ, new ArgType(false, ARG_ATOM, ARG_ATOM));}
 	static {setArgType(FNE, new ArgType(false, ARG_ATOM, ARG_ATOM));}
 
+	@LMNtalIL public static final int FLOAT2INT = 630; 
+	@LMNtalIL public static final int INT2FLOAT = 631; 
+	static {setArgType(FLOAT2INT, new ArgType(true, ARG_ATOM, ARG_ATOM));} 
+	static {setArgType(INT2FLOAT, new ArgType(true, ARG_ATOM, ARG_ATOM));} 
+	@LMNtalIL public static final int FLOAT2INTFUNC = FLOAT2INT + OPT; 
+	@LMNtalIL public static final int INT2FLOATFUNC = INT2FLOAT + OPT; 
+	static {setArgType(FLOAT2INTFUNC, new ArgType(true, ARG_VAR, ARG_VAR));} 
+	static {setArgType(INT2FLOATFUNC, new ArgType(true, ARG_VAR, ARG_VAR));} 
+	
 	//グループ化に関する命令
 	/**
 	 * group [subinsts]

--- a/src/util/GlobalSystemRulesetGenerator.java
+++ b/src/util/GlobalSystemRulesetGenerator.java
@@ -283,6 +283,8 @@ public final class GlobalSystemRulesetGenerator {
 		ruleset.rules.add(buildUnaryPlusRule("+.", Instruction.ISFLOAT));
 		ruleset.rules.add(buildUnaryOpRule("-",    Instruction.ISINT,  Instruction.INEG));
 		ruleset.rules.add(buildUnaryOpRule("-.",   Instruction.ISFLOAT,Instruction.FNEG));
+		ruleset.rules.add(buildUnaryOpRule("int",  Instruction.ISFLOAT,Instruction.FLOAT2INT)); 
+		ruleset.rules.add(buildUnaryOpRule("float",Instruction.ISINT,  Instruction.INT2FLOAT)); 
 		
 //		// 1:cp(A,B,C), 2:$n[A] :- unary($n) | $3:$n[B], $4:$n[C].
 //		// reuse { 2->4 }


### PR DESCRIPTION
develop からブランチを切ったので、改めてプルリクを送る。

中間命令 "float2int" 及び "int2float" を搭載した。
手元で正しく出力されることが確認できた。

具体的には以下の変更を行なった。
https://github.com/lmntal/lmntal-compiler/blob/054f1bf46601cc9c04b4b4facee14d1031c4f14a/src/runtime/Instruction.java#L1481-L1489
ここで "float2int" と "int2float" をそれぞれ int 型の識別子 INT2FLOAT, FLOAT2INT を key としてマップを作成させ、
https://github.com/lmntal/lmntal-compiler/blob/054f1bf46601cc9c04b4b4facee14d1031c4f14a/src/compile/GuardCompiler.java#L118-L119
ここでアトム名と引数で SymbolFunctor を作り、これを key としてマップを作成させ、
https://github.com/lmntal/lmntal-compiler/blob/054f1bf46601cc9c04b4b4facee14d1031c4f14a/src/util/GlobalSystemRulesetGenerator.java#L286-L287
ここで "float2int" と "int2float" の中間命令を作成している。