### PR TITLE
bugfix to process hlink(H,attribute) in guard

### DIFF
--- a/src/compile/GuardCompiler.java
+++ b/src/compile/GuardCompiler.java
@@ -608,6 +608,7 @@ class GuardCompiler extends LHSCompiler
 					{
 						int[] desc = array(ISHLINK);
 						if (!identifiedCxtdefs.contains(def1)) continue;
+						if (!identifiedCxtdefs.contains(def2)) continue;
 						int atomid1 = loadUnaryAtom(def1);
 						int dstatomid = varCount++;
 						if (desc[0] != 0 && (!typedCxtDataTypes.containsKey(def1) || desc[0] != typedCxtDataTypes.get(def1)))


### PR DESCRIPTION
1.43 までは属性つきハイパーリンクのチェック（例：... :- hlink(L,1) | ...）のコード生成ができていたが，1.44以降（他の改変に伴い）できなくなっていたのを修正した．