### PR TITLE
Feature/ground

### DIFF
--- a/src/compile/GuardCompiler.java
+++ b/src/compile/GuardCompiler.java
@@ -441,7 +441,13 @@ class GuardCompiler extends LHSCompiler
 //							Env.p("VAR## "+srcPath);
 							if(srcPath==UNBOUND) continue FixType;
 							uniqVars.add(srcPath);
+
+						// System.out.println("typedCxtTypes, defK: " + typedCxtTypes + " " + defK);
+						// System.out.println("hlgroundAttrs: " + hlgroundAttrs);
+
+						hlgroundAttrs.put(defK, new Atom[0]);
 						}
+
 						match.add(new Instruction(Instruction.UNIQ, uniqVars));
 						rc.theRule.hasUniq = true;
 					}

--- a/src/compile/GuardCompiler.java
+++ b/src/compile/GuardCompiler.java
@@ -432,9 +432,17 @@ class GuardCompiler extends LHSCompiler
 							ContextDef defK = ((ProcessContext)cstr.args[k].buddy.atom).def;
 							if (!identifiedCxtdefs.contains(defK)) continue FixType; // 未割り当てのプロセス（表記に-が付くもの）は認めない
 							int srcPath;
+
 //							srcPath = typedcxtToSrcPath(defK);
 //							Env.p("VAR# "+srcPath);
 //							if(srcPath==UNBOUND) {
+
+							if (typedCxtTypes.get(defK) != GROUND_LINK_TYPE) {
+								hlgroundAttrs.put(defK, new Atom[0]);  // hyperlink attributes not handled
+							} else if (hlgroundAttrs.get(defK).length != 0) {
+								error("COMPILE ERROR: incompatible attributes in ground constraints");
+							}
+
 							checkGroundLink(defK);
 							srcPath = groundToSrcPath(defK);
 //							}
@@ -444,8 +452,6 @@ class GuardCompiler extends LHSCompiler
 
 						// System.out.println("typedCxtTypes, defK: " + typedCxtTypes + " " + defK);
 						// System.out.println("hlgroundAttrs: " + hlgroundAttrs);
-
-						hlgroundAttrs.put(defK, new Atom[0]);
 						}
 
 						match.add(new Instruction(Instruction.UNIQ, uniqVars));

--- a/src/compile/RuleCompiler.java
+++ b/src/compile/RuleCompiler.java
@@ -898,12 +898,17 @@ public class RuleCompiler
 					rhstypedcxtpaths.put(pc, atompath);
 					rhsmappaths.put(pc, atompath);
 				}
+				// TODO: refactor                                                    // ueda
 				else if (gc.typedCxtTypes.get(def) == GuardCompiler.GROUND_LINK_TYPE)
 				{
 					int retlistpath = varcount++;
+					// System.out.println("buildRHSTypedProcesses, def: " + def);
+
+					Atom[] atoms = this.gc.hlgroundAttrs.get(def); // hlgroundの属性 // ueda 
+					List<Functor> attrs = this.gc.getHlgroundAttrs(atoms);           // ueda
 					body.add(new Instruction( Instruction.COPYGROUND, retlistpath,
 							groundToSrcPath(pc.def), // groundの場合はリンクの変数番号のリストを指す変数番号
-							rhsmemToPath(pc.mem) ));
+							rhsmemToPath(pc.mem), attrs));
 					int groundpath = varcount++;
 					body.add(new Instruction( Instruction.GETFROMLIST,groundpath,retlistpath,0));
 					int mappath = varcount++;

--- a/src/runtime/Instruction.java
+++ b/src/runtime/Instruction.java
@@ -1124,17 +1124,21 @@ public class Instruction implements Cloneable
 	static {setArgType(NEQGROUND, new ArgType(false, ARG_VAR, ARG_VAR));}
 
 	/**
-	 * copyground [-dstlist, srclinklist, dstmem]
+	 * copyground [-dstlist, srclinklist, dstmem, attrs]
 	 * 
 	 * （基底項プロセスを指す）リンク列$srclinklistを$dstmemに複製し、
 	 * $dstlistの第1要素はコピーされたリンク列を，
 	 * 第二要素にはコピー元のアトムからコピー先のアトムへのマップがそれぞれ格納される．
+	 * attrs を属性としたハイパーリンクは，コピー元の基底項に局所的ならばコピーされ
+	 * （つまり新たなハイパーリンクが作成され），局所的でないならばコピーされず共有される．
+	 * 属性をもたないハイパーリンクやattrs に指定されていない属性のハイパーリンクは
+	 * コピーされない．
 	 */
 	@LMNtalIL public static final int COPYGROUND = 218;
-	static {setArgType(COPYGROUND, new ArgType(true, ARG_VAR, ARG_VAR, ARG_MEM));}
+	static {setArgType(COPYGROUND, new ArgType(true, ARG_VAR, ARG_VAR, ARG_MEM, ARG_OBJS));}
 
 	/**
-	 * removeground [srclinklist,srcmem]
+	 * removeground [srclinklist, srcmem]
 	 * 
 	 * $srcmemに属する（基底項プロセスを指す）リンク列$srclinklistを現在の膜から取り出す。
 	 * 実行アトムスタックは操作しない。
@@ -1153,14 +1157,18 @@ public class Instruction implements Cloneable
 	// 型検査のためのガード命令 (221--229)	
 
 	/**
-	 * isground [-natomsfunc, linklist, avolist]
+	 * isground [-natomsfunc, linklist, avolist, attrs]
 	 * 
 	 * <br>（予約された）ロック取得する拡張ガード命令<br>
 	 * リンク列$linklistの指す先が基底項プロセスであることを確認する。
 	 * すなわち、リンク先から（戻らずに）到達可能なアトムが全てこの膜に存在していることを確認する。
 	 * ただし、$avolistに登録されたリンクに到達したら失敗する。
 	 * 見つかった基底項プロセスを構成するこの膜のアトムの個数（をラップしたInteger）を$natomsに格納する。
-	 * 
+	 *
+	 * 基底項プロセスのハイパーリンクはたどらないが，attrsに指定した属性のハイパーリンクで
+	 * すべての端点がこの基底項プロセスに属する場合，そのハイパーリンクはこの基底項プロセス
+	 * の局所ハイパーリンクといい，後続のcopyground命令で（共有でなく）新規作成の対象となる．
+	 *
 	 * <p>natomsとnmemsと統合した命令を作り、$natomsの総和を引数に渡すようにする。
 	 * 子膜の個数の照合は、本膜がロックしていない子膜の個数が0個かどうか調べればよい。
 	 * しかし本膜がロックしたかどうかを調べるメカニズムが今は備わっていないため、保留。
@@ -1168,7 +1176,7 @@ public class Instruction implements Cloneable
 	 * groundには膜は含まれないことになったので、上記は不要
 	 */
 	@LMNtalIL public static final int ISGROUND = 221;
-	static {setArgType(ISGROUND, new ArgType(true, ARG_VAR, ARG_VAR, ARG_VAR));}
+	static {setArgType(ISGROUND, new ArgType(true, ARG_VAR, ARG_VAR, ARG_VAR, ARG_OBJS));}
 
 	/**
 	 * isunary [atom]


### PR DESCRIPTION
拡張 ground，すなわち ground(ルート, 属性の並び) を扱うようにした版です．
isground および copyground 命令の引数が一つ増えたので，slim の develop ブランチが対応するまでは CI 通りません．
現時点では slim の feature/extended-ground とともに検査してください．
なお，removeground の引数は変化なしです．
isground の引数は今後のために追加しましたが，現在の slim では活用していません．