### PR TITLE
fix ci formatter

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -38,6 +38,13 @@ jobs:
       - name: Check for modified files
         id: git-check
         run: echo ::set-output name=modified::$(if git diff-index --quiet HEAD --; then echo "false"; else echo "true"; fi)
+
+      - name: Print debug
+        id: print-debug
+        run: |
+          git diff-index HEAD
+          git diff HEAD
+
       # 変更されていた場合、コミット・プッシュを行う(※3)
       - name: Push
         if: steps.git-check.outputs.modified == 'true'

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -37,14 +37,7 @@ jobs:
       # 変更確認
       - name: Check for modified files
         id: git-check
-        # run: echo ::set-output name=modified::$(if git diff-index --quiet HEAD --; then echo "false"; else echo "true"; fi)
         run: echo ::set-output name=modified::$(if git diff --quiet HEAD --; then echo "false"; else echo "true"; fi)
-
-      - name: Print debug
-        id: print-debug
-        run: |
-          git diff-index HEAD
-          git diff HEAD
 
       # 変更されていた場合、コミット・プッシュを行う(※3)
       - name: Push

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -37,7 +37,8 @@ jobs:
       # 変更確認
       - name: Check for modified files
         id: git-check
-        run: echo ::set-output name=modified::$(if git diff-index --quiet HEAD --; then echo "false"; else echo "true"; fi)
+        # run: echo ::set-output name=modified::$(if git diff-index --quiet HEAD --; then echo "false"; else echo "true"; fi)
+        run: echo ::set-output name=modified::$(if git diff --quiet HEAD --; then echo "false"; else echo "true"; fi)
 
       - name: Print debug
         id: print-debug

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -35,12 +35,9 @@ jobs:
       # プルリクエスト時の変更を取る場合はgit log
       # で変更差分のみ取得してフォーマッタをかけましょう。(※2)
       # 変更確認
-      # 追記：grep -vE 'package-lock.json$' で，package-lock.json の変更は無視している
       - name: Check for modified files
         id: git-check
-        run: echo ::set-output name=modified::$(if [[ $(git diff-index HEAD | grep -vE 'package-lock.json$' | wc -l) -gt 0  ]]; then echo 'true'; else echo 'false'; fi)
-        # run: echo ::set-output name=modified::$(if git diff-index --quiet HEAD --; then echo "false"; else echo "true"; fi)
-
+        run: echo ::set-output name=modified::$(if git diff-index --quiet HEAD --; then echo "false"; else echo "true"; fi)
       # 変更されていた場合、コミット・プッシュを行う(※3)
       - name: Push
         if: steps.git-check.outputs.modified == 'true'

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -35,9 +35,12 @@ jobs:
       # プルリクエスト時の変更を取る場合はgit log
       # で変更差分のみ取得してフォーマッタをかけましょう。(※2)
       # 変更確認
+      # 追記：grep -vE 'package-lock.json$' で，package-lock.json の変更は無視している
       - name: Check for modified files
         id: git-check
-        run: echo ::set-output name=modified::$(if git diff-index --quiet HEAD --; then echo "false"; else echo "true"; fi)
+        run: echo ::set-output name=modified::$(if [[ $(git diff-index HEAD | grep -vE 'package-lock.json$' | wc -l) -gt 0  ]]; then echo 'true'; else echo 'false'; fi)
+        # run: echo ::set-output name=modified::$(if git diff-index --quiet HEAD --; then echo "false"; else echo "true"; fi)
+
       # 変更されていた場合、コミット・プッシュを行う(※3)
       - name: Push
         if: steps.git-check.outputs.modified == 'true'

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "devDependencies": {
-        "prettier-plugin-java": "^1.6.1"
+        "prettier-plugin-java": "0.8.3"
       }
     },
     "node_modules/chevrotain": {
@@ -18,25 +18,25 @@
       }
     },
     "node_modules/java-parser": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/java-parser/-/java-parser-2.0.1.tgz",
-      "integrity": "sha512-IPzs8LN8drvAZKbgW1MLLsrEeW4TwSy714I6ZHlEGNV6/42S2xRU5zDn3lP6uZQakwi7nyC00T6lZvwEnBujzw==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/java-parser/-/java-parser-0.8.2.tgz",
+      "integrity": "sha512-YphTEk4zIpWAHqBriAdjlNnTEcEYQ2xBA8KOH5V7QxggNbxjkeEcKJjNYnQvqEue8+O1TLj7vfL0NVG6x5LGMw==",
       "dev": true,
       "dependencies": {
         "chevrotain": "6.5.0",
-        "lodash": "4.17.21"
+        "lodash": "4.17.20"
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
     "node_modules/prettier": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.1.tgz",
-      "integrity": "sha512-p+vNbgpLjif/+D+DwAZAbndtRrR0md0MwfmOVN9N+2RgyACMT+7tfaRnT+WDPkqnuVwleyuBIG2XBxKDme3hPA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.1.tgz",
+      "integrity": "sha512-9bY+5ZWCfqj3ghYBLxApy2zf6m+NJo5GzmLTpr9FsApsfjriNnS2dahWReHMi7qNPhhHl9SYHJs2cHZLgexNIw==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -46,14 +46,14 @@
       }
     },
     "node_modules/prettier-plugin-java": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-java/-/prettier-plugin-java-1.6.1.tgz",
-      "integrity": "sha512-kSY17V/P88nILlILb5iMp16TVJy6Ls9Jy4zAzI4+GsEuRDZH5VqRuLd8aJS1ImWxVgRjNBmoFOjxYyxkRM0SRA==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-java/-/prettier-plugin-java-0.8.3.tgz",
+      "integrity": "sha512-LyFle106727RkY1NBGzHHnzEJKjILigSfHPPqalNi5yJ/DkM5hjOVxWa4374gm44LStMl1arNgzpCnYPL0F8cg==",
       "dev": true,
       "dependencies": {
-        "java-parser": "2.0.1",
-        "lodash": "4.17.21",
-        "prettier": "2.3.1"
+        "java-parser": "0.8.2",
+        "lodash": "4.17.20",
+        "prettier": "2.1.1"
       }
     },
     "node_modules/regexp-to-ast": {
@@ -74,36 +74,36 @@
       }
     },
     "java-parser": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/java-parser/-/java-parser-2.0.1.tgz",
-      "integrity": "sha512-IPzs8LN8drvAZKbgW1MLLsrEeW4TwSy714I6ZHlEGNV6/42S2xRU5zDn3lP6uZQakwi7nyC00T6lZvwEnBujzw==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/java-parser/-/java-parser-0.8.2.tgz",
+      "integrity": "sha512-YphTEk4zIpWAHqBriAdjlNnTEcEYQ2xBA8KOH5V7QxggNbxjkeEcKJjNYnQvqEue8+O1TLj7vfL0NVG6x5LGMw==",
       "dev": true,
       "requires": {
         "chevrotain": "6.5.0",
-        "lodash": "4.17.21"
+        "lodash": "4.17.20"
       }
     },
     "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
     "prettier": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.1.tgz",
-      "integrity": "sha512-p+vNbgpLjif/+D+DwAZAbndtRrR0md0MwfmOVN9N+2RgyACMT+7tfaRnT+WDPkqnuVwleyuBIG2XBxKDme3hPA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.1.tgz",
+      "integrity": "sha512-9bY+5ZWCfqj3ghYBLxApy2zf6m+NJo5GzmLTpr9FsApsfjriNnS2dahWReHMi7qNPhhHl9SYHJs2cHZLgexNIw==",
       "dev": true
     },
     "prettier-plugin-java": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-java/-/prettier-plugin-java-1.6.1.tgz",
-      "integrity": "sha512-kSY17V/P88nILlILb5iMp16TVJy6Ls9Jy4zAzI4+GsEuRDZH5VqRuLd8aJS1ImWxVgRjNBmoFOjxYyxkRM0SRA==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-java/-/prettier-plugin-java-0.8.3.tgz",
+      "integrity": "sha512-LyFle106727RkY1NBGzHHnzEJKjILigSfHPPqalNi5yJ/DkM5hjOVxWa4374gm44LStMl1arNgzpCnYPL0F8cg==",
       "dev": true,
       "requires": {
-        "java-parser": "2.0.1",
-        "lodash": "4.17.21",
-        "prettier": "2.3.1"
+        "java-parser": "0.8.2",
+        "lodash": "4.17.20",
+        "prettier": "2.1.1"
       }
     },
     "regexp-to-ast": {


### PR DESCRIPTION
# CI による自動 formatting のためのコードを一部変更

package-lock.json が github 上で更新されてしまうために，format 済のコードを P-R した時に push が走って，「変更を加えていないはずなのに commit している」というエラーになるという謎の現象が起きていた．

1. package-lock.json が github 上で更新される理由はよくわからない（なぜ？）
2. package-lock.json が更新された後に，それを commit していると思うのだが，そこで「変更を加えていない」ということになる理由がよくわからない．

とりあえず，format 後のコードの差分を見る際に，package-lock.json は無視するようにして回避した．
追記：package-lock.json の更新がされていなかったことに気づいたので revert した．
