### PR TITLE
Fix compile-rule

### DIFF
--- a/src/runtime/FrontEnd.java
+++ b/src/runtime/FrontEnd.java
@@ -450,7 +450,7 @@ public class FrontEnd {
 
       if (Env.compileRule) {
         try {
-          List<Ruleset> rulesets = m.rulesets;
+          List<Ruleset> rulesets = m.rules.get(0).rightMem.rulesets;
           InterpretedRuleset r = (InterpretedRuleset) rulesets.get(0);
           r.rules.get(0).showDetail();
         } catch (Exception e) {


### PR DESCRIPTION
`--compile-rule` オプションが正しく動作しなくなっていたのを修正

## `--compile-rule` オプションとは
1本のルールだけをコンパイルするモード。SLIMをLTLモードで実行する際に、（LMNtalルールとして書かれた）原子論理式のコンパイルのために呼ばれる。

## 背景・修正内容
昨年夏に「初期状態にハイパーリンク記法 `!X` が書けるようにする」ため、「初期プロセス」を返す `compileMembrane` 関数を廃止し、「初期プロセスを生成するルール」（いわば0ステップ目）を返すようにした。
その際、`--compile-only` の出力が修正されておらず、「初期プロセスを生成するルール」を出力するようになっていたので、ルールそのものを出力するように修正した。