### PR TITLE
added rule with parentheses to UnitAtom

### DIFF
--- a/src/compile/parser/lmntal.cup
+++ b/src/compile/parser/lmntal.cup
@@ -6,7 +6,7 @@ package compile.parser;
 import java.util.LinkedList;
 import compile.parser.MySymbol;
 
-parser code {: 
+parser code {:
 	public void report_error(String message, Object info) {
 		System.err.print(message);
 		if (info instanceof MySymbol) {
@@ -19,7 +19,7 @@ parser code {:
     public void unrecovered_syntax_error(java_cup.runtime.Symbol cur_token) throws Exception {
     	report_fatal_error("Couldn't repair and continue parse", null);
 	}
-    
+
 :};
 
 
@@ -30,8 +30,8 @@ terminal		COMMA, LPAREN, RPAREN, LBRACE,
 				RBRACE_UNDERBAR, RBRACE_UNDERBAR_SLASH,
 				RBRACE_UNDERBAR_AT, RBRACE_UNDERBAR_SLASH_AT,
 				RBRACE_ASTERISK,
-				COLON, PERIOD, BACKSLASH, GUARD, PROCVAR, RULEVAR, 
-				LBRACKET, RBRACKET, NEGATIVE, MOD, 
+				COLON, PERIOD, BACKSLASH, GUARD, PROCVAR, RULEVAR,
+				LBRACKET, RBRACKET, NEGATIVE, MOD,
 				LOGAND, LOGIOR, LOGXOR, /* LOGNOT, */ ASH,
 				HAT, TILDE, ASTERISK_ASTERISK,
 				ASTERISK_DOT, SLASH_DOT, PLUS_DOT, MINUS_DOT,
@@ -71,7 +71,6 @@ non terminal SrcProcessContext	ProcessContext;
 non terminal SrcRuleContext		RuleContext;
 non terminal SrcContext			Context;
 non terminal Object				Process;
-non terminal SrcRule			ProcessListContinuation;
 non terminal LinkedList			ProcessList;
 non terminal LinkedList			NonemptyProcessList;
 non terminal LinkedList			WorldProcessList;
@@ -156,37 +155,8 @@ UnitAtom ::=
       {: RESULT = new SrcAtom(name, list, nameleft, nameright); :}
   | List:list
       {: RESULT = list; :}
-//				| LPAREN Rule:rule RPAREN
-//					{: RESULT = rule; :}
-  | LPAREN RuleName:name RULENAMESEP ProcessList:list ProcessListContinuation:rule
-      {: rule.name = name;
-         if (rule == null) {
-           if (list.size() == 1) {
-             RESULT = list.getFirst();
-           }
-           else {
-             RESULT = list;
-           }
-         }
-         else {
-           rule.setHead(list);
-           RESULT = rule;
-         }
-      :}
-  | LPAREN ProcessList:list ProcessListContinuation:rule
-      {: if (rule == null) {
-           if (list.size() == 1) {
-             RESULT = list.getFirst();
-           }
-           else {
-             RESULT = list;
-           }
-         }
-         else {
-           rule.setHead(list);
-           RESULT = rule;
-         }
-      :}
+  | LPAREN Rule:rule RPAREN
+      {: RESULT = rule; :}
   | LPAREN QuotedOperatorAtom:atom RPAREN
       {: RESULT = atom; :}
   | Context:p
@@ -446,23 +416,6 @@ Rule ::=
       {: RESULT = new SrcRule(null, head, head2, guard, body, lineno.intValue()); :}
   | RuleName:name RULENAMESEP ProcessList:head BACKSLASH ProcessList:head2 RULE:lineno ProcessList:guard GUARD ProcessList:body
       {: RESULT = new SrcRule(name, head, head2, guard, body, lineno.intValue()); :}
-;
-
-// 「丸カッコありのルール構文、または丸カッコとカンマによる項組構文」のための非終端記号
-// こっちはルール名には非対応。(a,b,c :- ( 対応しているようだが…。)
-// 出現した行番号を追加 by Inui
-// simpagationを追加 by Kudo
-ProcessListContinuation ::=
-    RPAREN
-      {: RESULT = null; :}
-  | RULE:lineno ProcessList:body RPAREN
-      {: RESULT = new SrcRule(null, null, body, lineno.intValue()); :}
-  | RULE:lineno ProcessList:guard GUARD ProcessList:body RPAREN
-      {: RESULT = new SrcRule(null, null, guard, body, lineno.intValue()); :}
-  | BACKSLASH ProcessList:head2 RULE:lineno ProcessList:body RPAREN
-      {: RESULT = new SrcRule(null, null, head2, null, body, lineno.intValue()); :}
-  | BACKSLASH ProcessList:head2 RULE:lineno ProcessList:guard GUARD ProcessList:body RPAREN
-      {: RESULT = new SrcRule(null, null, head2, guard, body, lineno.intValue()); :}
 ;
 
 ProcessContext ::=

--- a/src/compile/parser/lmntal.cup
+++ b/src/compile/parser/lmntal.cup
@@ -169,11 +169,7 @@ UnitAtom ::=
           } :}
   // RuleNameがある場合
   | LPAREN RuleName:name RULENAMESEP ProcessList:list RULE:lineno ProcessList:body RPAREN
-      {: if (list.size() == 1) {
-            RESULT = list.getFirst();
-          } else {
-            RESULT = list;
-          } :}
+      {: RESULT = new SrcRule(name, list, body, lineno.intValue()); :}
   | LPAREN RuleName:name RULENAMESEP ProcessList:list RULE:lineno ProcessList:guard GUARD ProcessList:body RPAREN
       {: RESULT = new SrcRule(name, list, guard, body, lineno.intValue()); :}
   | LPAREN RuleName:name RULENAMESEP ProcessList:list BACKSLASH ProcessList:head2 RULE:lineno ProcessList:body RPAREN

--- a/src/compile/parser/lmntal.cup
+++ b/src/compile/parser/lmntal.cup
@@ -155,8 +155,30 @@ UnitAtom ::=
       {: RESULT = new SrcAtom(name, list, nameleft, nameright); :}
   | List:list
       {: RESULT = list; :}
-  | LPAREN Rule:rule RPAREN
-      {: RESULT = rule; :}
+				// | LPAREN Rule:p RPAREN
+				// 	{: LinkedList list = new LinkedList(); list.add(p); RESULT = list;
+        //     System.out.println("p: " + p);
+        //     :}
+
+  // 「丸カッコありのルール構文、または丸カッコとカンマによる項組構文」のための非終端記号
+  | LPAREN ProcessList:list RPAREN
+      {: RESULT = list; :}
+  | LPAREN RuleName:name RULENAMESEP ProcessList:list RULE:lineno ProcessList:body RPAREN
+      {:RESULT = new SrcRule(name, list, body, lineno.intValue());:}
+  | LPAREN RuleName:name RULENAMESEP ProcessList:list RULE:lineno ProcessList:guard GUARD ProcessList:body RPAREN
+      {:RESULT = new SrcRule(name, list, guard, body, lineno.intValue());:}
+  | LPAREN RuleName:name RULENAMESEP ProcessList:list BACKSLASH ProcessList:head2 RULE:lineno ProcessList:body RPAREN
+      {:RESULT = new SrcRule(name, list, head2, null, body, lineno.intValue());:}
+  | LPAREN RuleName:name RULENAMESEP ProcessList:list BACKSLASH ProcessList:head2 RULE:lineno ProcessList:guard GUARD ProcessList:body RPAREN
+      {:RESULT = new SrcRule(name, list, head2, guard, body, lineno.intValue());:}
+  | LPAREN ProcessList:list RULE:lineno ProcessList:body RPAREN
+      {:RESULT = new SrcRule(null, list, body, lineno.intValue());:}
+  | LPAREN ProcessList:list RULE:lineno ProcessList:guard GUARD ProcessList:body RPAREN
+      {:RESULT = new SrcRule(null, list, guard, body, lineno.intValue());:}
+  | LPAREN ProcessList:list BACKSLASH ProcessList:head2 RULE:lineno ProcessList:body RPAREN
+      {:RESULT = new SrcRule(null, list, head2, null, body, lineno.intValue());:}
+  | LPAREN ProcessList:list BACKSLASH ProcessList:head2 RULE:lineno ProcessList:guard GUARD ProcessList:body RPAREN
+      {:RESULT = new SrcRule(null, list, head2, guard, body, lineno.intValue());:}
   | LPAREN QuotedOperatorAtom:atom RPAREN
       {: RESULT = atom; :}
   | Context:p

--- a/src/compile/parser/lmntal.cup
+++ b/src/compile/parser/lmntal.cup
@@ -162,23 +162,33 @@ UnitAtom ::=
 
   // 「丸カッコありのルール構文、または丸カッコとカンマによる項組構文」のための非終端記号
   | LPAREN ProcessList:list RPAREN
-      {: RESULT = list; :}
+      {: if (list.size() == 1) {
+            RESULT = list.getFirst();
+          } else {
+            RESULT = list;
+          } :}
+  // RuleNameがある場合
   | LPAREN RuleName:name RULENAMESEP ProcessList:list RULE:lineno ProcessList:body RPAREN
-      {:RESULT = new SrcRule(name, list, body, lineno.intValue());:}
+      {: if (list.size() == 1) {
+            RESULT = list.getFirst();
+          } else {
+            RESULT = list;
+          } :}
   | LPAREN RuleName:name RULENAMESEP ProcessList:list RULE:lineno ProcessList:guard GUARD ProcessList:body RPAREN
-      {:RESULT = new SrcRule(name, list, guard, body, lineno.intValue());:}
+      {: RESULT = new SrcRule(name, list, guard, body, lineno.intValue()); :}
   | LPAREN RuleName:name RULENAMESEP ProcessList:list BACKSLASH ProcessList:head2 RULE:lineno ProcessList:body RPAREN
-      {:RESULT = new SrcRule(name, list, head2, null, body, lineno.intValue());:}
+      {: RESULT = new SrcRule(name, list, head2, null, body, lineno.intValue()); :}
   | LPAREN RuleName:name RULENAMESEP ProcessList:list BACKSLASH ProcessList:head2 RULE:lineno ProcessList:guard GUARD ProcessList:body RPAREN
-      {:RESULT = new SrcRule(name, list, head2, guard, body, lineno.intValue());:}
+      {: RESULT = new SrcRule(name, list, head2, guard, body, lineno.intValue()); :}
+  // RuleNameがない場合
   | LPAREN ProcessList:list RULE:lineno ProcessList:body RPAREN
-      {:RESULT = new SrcRule(null, list, body, lineno.intValue());:}
+      {: RESULT = new SrcRule(null, list, body, lineno.intValue()); :}
   | LPAREN ProcessList:list RULE:lineno ProcessList:guard GUARD ProcessList:body RPAREN
-      {:RESULT = new SrcRule(null, list, guard, body, lineno.intValue());:}
+      {: RESULT = new SrcRule(null, list, guard, body, lineno.intValue()); :}
   | LPAREN ProcessList:list BACKSLASH ProcessList:head2 RULE:lineno ProcessList:body RPAREN
-      {:RESULT = new SrcRule(null, list, head2, null, body, lineno.intValue());:}
+      {: RESULT = new SrcRule(null, list, head2, null, body, lineno.intValue()); :}
   | LPAREN ProcessList:list BACKSLASH ProcessList:head2 RULE:lineno ProcessList:guard GUARD ProcessList:body RPAREN
-      {:RESULT = new SrcRule(null, list, head2, guard, body, lineno.intValue());:}
+      {: RESULT = new SrcRule(null, list, head2, guard, body, lineno.intValue()); :}
   | LPAREN QuotedOperatorAtom:atom RPAREN
       {: RESULT = atom; :}
   | Context:p


### PR DESCRIPTION
## 指摘

- 以下のプログラムで、atobは適用されるのに、ハイパーリンクを含むntomは適用されない。ntom2は適用される。
```
init.
init :- n(!I), a, (ntom@@ n(!A):-m(!A), m(!A)), (atob@@ a:-b).
ntom2@@ n(!A):-m(!A),m(!A).
```

## 原因

- [「丸カッコありのルール構文、または丸カッコとカンマによる項組構文」のための非終端記号](https://github.com/lmntal/lmntal-compiler/blob/e16424d40df28627706bde753917cb71885f09cc/src/compile/parser/lmntal.cup#L458)で、カッコ内にbodyだけがある構造にパターンマッチしており、rule nameとheadにnullが挿入されている
- このため、[addHyperLinkConstraint](https://github.com/lmntal/lmntal-compiler/blob/e16424d40df28627706bde753917cb71885f09cc/src/compile/parser/SrcRule.java#L116)でntomのガード部にhlink(A)ではなくnew(A)が挿入されている。

## 変更点

- UnitAtomのパターンマッチで、headを挿入したあとにSrcRuleが実行されるように書き換えた

![image](https://github.com/lmntal/lmntal-compiler/assets/82920808/3a06a677-e08c-4328-999b-e04fd8715829)

## 補足

- [lmntal.cupのコメントアウトされている部分](https://github.com/lmntal/lmntal-compiler/blob/a4da194e45a6b3d6e51164b01edddb7dc9954f90/src/compile/parser/lmntal.cup#L158)を採用すると、今回のプログラムではうまく行くが、array2D.lmnが失敗する。
